### PR TITLE
Fix: default local IP should be 127.0.0.1

### DIFF
--- a/config/server.json
+++ b/config/server.json
@@ -1,5 +1,5 @@
 {
-  "host": "0.0.0.0",
+  "host": "127.0.0.1",
   "port": 8000,
   "https": false,
   "keyFile": "config/key.pem",


### PR DESCRIPTION
Currently, default configuration binds the Express server to `0.0.0.0:8000`. However, that alias is not respected on all operating systems, so this should be changed to `127.0.0.1` by default. If a user wishes to change this to `0.0.0.0` down the line, then they can  do so at their own discretion.

This allows for the program to work universally out-of-the-box.